### PR TITLE
Add engine support for hyper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,11 @@ name = "rench"
 version = "0.1.0"
 dependencies = [
  "clap 2.29.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.11.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,7 @@ travis-ci = { repository = "kbacha/rench" }
 [dependencies]
 clap = "2.29"
 reqwest = "0.8"
+hyper = "0.11"
+hyper-tls = "0.1"
+tokio-core = "0.1"
+futures = "0.1"

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,14 +1,18 @@
 use bench;
 use stats::Fact;
+use content_length::ContentLength;
 
+#[derive(Clone)]
 pub struct Engine {
     urls: Vec<String>,
     requests: usize,
     kind: EngineKind,
 }
 
+#[derive(Clone)]
 enum EngineKind {
     Reqwest,
+    Hyper,
 }
 
 impl Engine {
@@ -20,14 +24,20 @@ impl Engine {
         }
     }
 
+    pub fn with_hyper(mut self) -> Self {
+        self.kind = EngineKind::Hyper;
+        self
+    }
+
     pub fn run<F>(self, f: F) where F: FnMut(Fact) {
         match &self.kind {
             &EngineKind::Reqwest => self.run_reqwest(f),
+            &EngineKind::Hyper => self.run_hyper(f),
         };
     }
 
     fn run_reqwest<F>(&self, mut f: F) where F: FnMut(Fact) {
-        use reqwest::{Client, Method, Request};
+        use reqwest::{header, Client, Method, Request};
         let client = Client::new();
 
         for n in 0..self.requests {
@@ -41,7 +51,44 @@ impl Engine {
                 let _ = resp.text();
                 resp
             });
-            f(Fact::record(resp, duration));
+            let len = resp.headers()
+                .get::<header::ContentLength>()
+                .map(|len| **len)
+                .unwrap_or(0);
+
+            f(Fact::record(ContentLength::new(len), resp.status().as_u16(), duration));
+        }
+    }
+
+    fn run_hyper<F>(&self, mut f: F) where F: FnMut(Fact) {
+        use hyper::{header, Client, Request, Method, Uri};
+        use hyper_tls::HttpsConnector;
+        use tokio_core::reactor::Core;
+        use futures::{Future, Stream};
+
+        let mut core = Core::new().expect("Setting up tokio core failed");
+        let handle = core.handle();
+        let client = Client::configure()
+            .connector(HttpsConnector::new(1, &handle).expect("To set up a http connector"))
+            .build(&handle);
+
+        let urls: Vec<Uri> = self.urls.iter().map(|url| url.parse().unwrap()).collect();
+
+        for n in 0..self.requests {
+            let uri = &urls[n % urls.len()];
+            let request = client.request(Request::new(Method::Get, uri.clone()))
+                .and_then(|response| {
+                    let status = response.status().as_u16();
+                    let content_length = response.headers()
+                        .get::<header::ContentLength>()
+                        .map(|len| len.0)
+                        .unwrap_or(0);
+                    response.body()
+                        .concat2()
+                        .map(move |_| (status, content_length))
+                 });
+            let ((status, content_length), duration) = bench::time_it(|| core.run(request).expect("reactor run"));
+            f(Fact::record(ContentLength::new(content_length), status, duration));
         }
     }
 }
@@ -53,6 +100,14 @@ mod tests {
     #[test]
     fn reqwest_engine_can_collect_facts() {
         let eng = Engine::new(vec!["https://www.google.com".to_string()], 1);
+        let mut fact: Option<Fact> = None;
+        eng.run(|f| fact = Some(f));
+        assert!(fact.is_some());
+    }
+
+    #[test]
+    fn hyper_engine_can_collect_facts() {
+        let eng = Engine::new(vec!["https://www.google.com".to_string()], 1).with_hyper();
         let mut fact: Option<Fact> = None;
         eng.run(|f| fact = Some(f));
         assert!(fact.is_some());

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,8 +1,6 @@
 use std::time::Duration;
-use reqwest::{header, Response, StatusCode};
-use std::fmt;
+use std::{cmp, fmt};
 use chart::Chart;
-use std::cmp;
 use content_length::ContentLength;
 
 trait ToMilliseconds {
@@ -27,22 +25,17 @@ mod millisecond_tests {
 
 #[derive(Debug)]
 pub struct Fact {
-    status: StatusCode,
+    status: u16,
     duration: Duration,
     content_length: ContentLength,
 }
 
 impl Fact {
-    pub fn record(resp: Response, duration: Duration) -> Fact {
-        let content_length = resp.headers()
-            .get::<header::ContentLength>()
-            .map(|len| **len)
-            .unwrap_or(0);
-
+    pub fn record(content_length: ContentLength, status: u16, duration: Duration) -> Fact {
         Fact {
             duration,
-            status: resp.status(),
-            content_length: ContentLength::new(content_length),
+            status,
+            content_length,
         }
     }
 }
@@ -203,7 +196,7 @@ mod summary_tests {
 
     fn ok_zero_length_fact(duration: Duration) -> Fact {
         Fact {
-            status: StatusCode::Ok,
+            status: 200,
             duration: duration,
             content_length: ContentLength::zero(),
         }
@@ -211,7 +204,7 @@ mod summary_tests {
 
     fn ok_instant_fact(content_length: ContentLength) -> Fact {
         Fact {
-            status: StatusCode::Ok,
+            status: 200,
             duration: Duration::new(0, 0),
             content_length,
         }


### PR DESCRIPTION
In order to compare reqwest to hyper I wanted to have both inside the
same compiled binary. I also wanted to be able to specify which engine
to use so I can run it twice. To do this I did the following:

1. Changed Facts to no longer be dependent on the reqwest types
2. Implemented a hyper enginer function
3. Set up an engine argument for specifying which engine to use.

In the end, this pulls in a few more dependencies but provided a clear
methodology for running either client.

Hyper:
```
$ ./target/release/rench -c 2 --engine=hyper -n 10000 http://0.0.0.0:6767/api/release-name/abc
Beginning requests
1000 requests
2000 requests
3000 requests
4000 requests
5000 requests
6000 requests
7000 requests
8000 requests
9000 requests
10000 requests
Finished!

Took 1.180455437 seconds
8471.306655517568 requests / second

Summary
  Average:   0.227237 ms
  Median:    0.167963 ms
  Longest:   4.742331 ms
  Shortest:  0.101747 ms
  Requests:  10000
  Data:      253.91 KB

Latency Percentiles (2% of requests per bar):
                                                 ▌ 0.493388
                                                 ▌
                                                 ▌
                                                 ▌
                                              ▖▖▌▌
                                      ▖▖▖▖▖▌▌▌▌▌▌▌
           ▖▖▖▖▖▖▖▖▖▖▖▖▖▖▖▖▖▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌
▖▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌
▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌
▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌ 0


Latency Histogram (each bar is 2% of max latency)
 ▌                                                 7021
 ▌
 ▌
 ▌
 ▌
 ▌
 ▌▌
 ▌▌
 ▌▌
 ▌▌▖▖▖▖▖▖      ▖▖▖▖▖▖▖  ▖▖▖▖▖▖▖▖▖▖▖▖▖▖▖ ▖▖▖      ▖ 0
```

Reqwest:
```
$ ./target/release/rench -c 2 --engine=reqwest -n 10000 http://0.0.0.0:6767/api/release-name/abc
Beginning requests
1000 requests
2000 requests
3000 requests
4000 requests
5000 requests
6000 requests
7000 requests
8000 requests
9000 requests
10000 requests
Finished!

Took 1.8915612149999999 seconds
5286.638317967416 requests / second

Summary
  Average:   0.361078 ms
  Median:    0.243408 ms
  Longest:   3.386871 ms
  Shortest:  0.157908 ms
  Requests:  10000
  Data:      253.91 KB

Latency Percentiles (2% of requests per bar):
                                                ▖▌ 2.61588
                                                ▌▌
                                                ▌▌
                                                ▌▌
                                                ▌▌
                                                ▌▌
                                                ▌▌
                                                ▌▌
                                ▖▖▖▖▖▖▖▖▖▖▖▖▖▖▖▖▌▌
▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌▌ 0


Latency Histogram (each bar is 2% of max latency)
   ▌                                               5665
   ▌
   ▌
   ▌
   ▌
   ▌▖
   ▌▌
   ▌▌
  ▌▌▌
  ▌▌▌▖▖▖     ▖        ▖▖▖▖  ▖▖ ▖▖ ▖▖▖▖▖▖▖▖▖▖ ▖▖▖ ▖ 0
```