### PR TITLE
Refactored out the collector and runner

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -1,0 +1,59 @@
+use std::{cmp, thread, sync::mpsc::{channel, Receiver, Sender}};
+use message::Message;
+use plan::Plan;
+
+pub fn start<T>(plan: Plan) -> (Sender<Message<T>>, thread::JoinHandle<Vec<T>>)
+where
+    T: 'static + Send,
+{
+    let (sender, receiver) = channel::<Message<T>>();
+    (sender, thread::spawn(move || collect(&receiver, plan)))
+}
+
+fn collect<T>(receiver: &Receiver<Message<T>>, plan: Plan) -> Vec<T>
+where
+    T: 'static + Send,
+{
+    let chunk_size = cmp::max(plan.requests() / 10, 1);
+    let mut eof_count = 0;
+    let mut messages: Vec<T> = Vec::with_capacity(plan.requests());
+
+    while eof_count < plan.threads() {
+        match receiver.recv().expect("To receive correctly") {
+            Message::Body(message) => {
+                messages.push(message);
+                if (messages.len() % (chunk_size)) == 0 {
+                    println!("{} requests", messages.len());
+                }
+            }
+            Message::EOF => eof_count += 1,
+        }
+    }
+    messages
+}
+
+#[cfg(test)]
+mod message_collection_tests {
+    use super::*;
+
+    #[test]
+    fn it_ends_when_all_nones_are_received() {
+        let plan = Plan::new(4, 0);
+        let (tx, handle) = start::<usize>(plan);
+        for _ in 0..4 {
+            let _ = tx.send(Message::EOF);
+        }
+        assert_eq!(handle.join().unwrap(), Vec::<usize>::new());
+    }
+
+    #[test]
+    fn it_collects_all_data_received() {
+        let plan = Plan::new(1, 0);
+        let (tx, handle) = start::<usize>(plan);
+        for n in 0..5 {
+            let _ = tx.send(Message::Body(n as usize));
+        }
+        let _ = tx.send(Message::EOF);
+        assert_eq!(handle.join().unwrap(), vec![0, 1, 2, 3, 4]);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,108 +6,19 @@ extern crate reqwest;
 extern crate tokio_core;
 
 use clap::{App, Arg};
-use std::thread;
-use std::cmp;
-use std::sync::mpsc::{channel, Receiver, Sender};
 
-mod content_length;
-mod stats;
-mod chart;
-mod engine;
 mod bench;
+mod chart;
+mod collector;
+mod content_length;
+mod engine;
+mod message;
+mod plan;
+mod runner;
+mod stats;
 use stats::{ChartSize, Fact, Summary};
-
-fn make_requests(eng: engine::Engine, sender: &Sender<Message<Fact>>) {
-    eng.run(|fact| {
-        sender
-            .send(Message::Body(fact))
-            .expect("to send the fact correctly");
-    });
-    sender.send(Message::EOF).expect("to send None correctly");
-}
-
-fn distribute_work(threads: usize, requests: usize) -> Vec<usize> {
-    // Every thread should get even work:
-    let base_work = requests / threads;
-    let remaining_work = requests % threads;
-
-    (0..threads)
-        .map(|thread| {
-            // The remainder means that we don't have enough for
-            // every thread to get 1. So we just add one until
-            // we've used up the entire remainder
-            if thread < remaining_work {
-                base_work + 1
-            } else {
-                base_work
-            }
-        })
-        .collect()
-}
-
-#[test]
-fn it_can_distribute_all_work_as_evenly_as_possible() {
-    assert_eq!(distribute_work(3, 1000), vec![334, 333, 333]);
-    assert_eq!(distribute_work(2, 1000), vec![500, 500]);
-    assert_eq!(
-        distribute_work(20, 39),
-        vec![2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1]
-    );
-}
-
-enum Message<T> {
-    Body(T),
-    EOF,
-}
-
-fn recv_messages<T>(
-    rx: &Receiver<Message<T>>,
-    expected_message_count: usize,
-    sender_count: usize,
-) -> Vec<T> {
-    let chunk_size = cmp::max(expected_message_count / 10, 1);
-    let mut eof_count = 0;
-    let mut messages: Vec<T> = Vec::with_capacity(expected_message_count);
-
-    while eof_count < sender_count {
-        match rx.recv().expect("To receive correctly") {
-            Message::Body(message) => {
-                messages.push(message);
-                if (messages.len() % (chunk_size)) == 0 {
-                    println!("{} requests", messages.len());
-                }
-            }
-            Message::EOF => eof_count += 1,
-        }
-    }
-    messages
-}
-
-#[cfg(test)]
-mod message_collection_tests {
-    use super::*;
-
-    #[test]
-    fn it_ends_when_all_nones_are_received() {
-        let (tx, rx) = channel::<Message<usize>>();
-        let handle = thread::spawn(move || recv_messages(&rx, 0, 4));
-        for _ in 0..4 {
-            let _ = tx.send(Message::EOF);
-        }
-        assert_eq!(handle.join().unwrap(), Vec::<usize>::new());
-    }
-
-    #[test]
-    fn it_collects_all_data_received() {
-        let (tx, rx) = channel::<Message<usize>>();
-        let handle = thread::spawn(move || recv_messages(&rx, 0, 1));
-        for n in 0..5 {
-            let _ = tx.send(Message::Body(n as usize));
-        }
-        let _ = tx.send(Message::EOF);
-        assert_eq!(handle.join().unwrap(), vec![0, 1, 2, 3, 4]);
-    }
-}
+use plan::Plan;
+use runner::Runner;
 
 fn main() {
     let matches = App::new("Git Release Names")
@@ -171,14 +82,6 @@ fn main() {
         .parse::<usize>()
         .expect("Expected valid number for number of requests");
 
-    let engine_kind = matches.value_of("engine").unwrap_or("reqwest");
-
-    let (sender, receiver) = channel::<Message<Fact>>();
-
-    let rec_handle = thread::spawn(move || recv_messages(&receiver, requests, threads));
-
-    let is_head_requests = matches.is_present("head-requests");
-
     let chart_size = match matches.value_of("chart-size").unwrap_or("medium") {
         "none" | "n" => ChartSize::None,
         "small" | "s" => ChartSize::Small,
@@ -187,27 +90,24 @@ fn main() {
         _ => unreachable!(),
     };
 
-    println!("Beginning requests");
-    let handles: Vec<thread::JoinHandle<()>> = distribute_work(threads, requests)
-        .into_iter()
-        .map(|work| {
-            let mut eng = match engine_kind {
-                "hyper" => engine::Engine::new(urls.clone(), work).with_hyper(),
-                "reqwest" | _ => engine::Engine::new(urls.clone(), work),
-            };
-            if is_head_requests {
-                eng = eng.with_method(engine::Method::Head);
-            }
-            let tx = sender.clone();
-            thread::spawn(move || make_requests(eng, &tx))
-        })
-        .collect();
+    let plan = Plan::new(threads, requests);
 
-    let ((), duration) = bench::time_it(|| {
-        handles
-            .into_iter()
-            .for_each(|h| h.join().expect("Sending thread to finish"));
-    });
+    let eng = match matches.value_of("engine").unwrap_or("reqwest") {
+        "hyper" => engine::Engine::new(urls.clone()).with_hyper(),
+        "reqwest" | _ => engine::Engine::new(urls.clone()),
+    };
+
+    let eng = if matches.is_present("head-requests") {
+        eng.with_method(engine::Method::Head)
+    } else {
+        eng
+    };
+
+    let (collector, rec_handle) = collector::start::<Fact>(plan);
+    let runner = Runner::start(plan, &eng, &collector);
+
+    println!("Beginning requests");
+    let ((), duration) = bench::time_it(|| runner.join());
     let facts = rec_handle.join().expect("Receiving thread to finish");
     let seconds =
         duration.as_secs() as f64 + (f64::from(duration.subsec_nanos()) / 1_000_000_000f64);

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,0 +1,7 @@
+pub enum Message<T>
+where
+    T: 'static + Send,
+{
+    Body(T),
+    EOF,
+}

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -1,0 +1,53 @@
+#[derive(Clone, Copy)]
+pub struct Plan {
+    threads: usize,
+    requests: usize,
+}
+
+impl Plan {
+    pub fn new(threads: usize, requests: usize) -> Self {
+        Self { threads, requests }
+    }
+
+    pub fn threads(&self) -> usize {
+        self.threads
+    }
+
+    pub fn requests(&self) -> usize {
+        self.requests
+    }
+
+    pub fn distribute(&self) -> Vec<usize> {
+        // Every thread should get even work:
+        let base_work = self.requests / self.threads;
+        let remaining_work = self.requests % self.threads;
+
+        (0..self.threads)
+            .map(|thread| {
+                // The remainder means that we don't have enough for
+                // every thread to get 1. So we just add one until
+                // we've used up the entire remainder
+                if thread < remaining_work {
+                    base_work + 1
+                } else {
+                    base_work
+                }
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_can_distribute_all_work_as_evenly_as_possible() {
+        assert_eq!(Plan::new(3, 1000).distribute(), vec![334, 333, 333]);
+        assert_eq!(Plan::new(2, 1000).distribute(), vec![500, 500]);
+        assert_eq!(
+            Plan::new(20, 39).distribute(),
+            vec![2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1]
+        );
+    }
+}

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,0 +1,46 @@
+use engine::Engine;
+use plan::Plan;
+use message::Message;
+use stats::Fact;
+use std::{thread, sync::mpsc::Sender};
+
+/// The runner struct represents an ongoing run time of the engine.
+pub struct Runner {
+    handles: Vec<thread::JoinHandle<()>>,
+}
+
+impl Runner {
+    /// Launches the runner with a plan. It will tell the engine to run and broadcast the
+    /// facts that the engine produces. The plan tells the runner how many threads to run
+    /// on and how to distribute the work.
+    pub fn start(plan: Plan, eng: &Engine, collector: &Sender<Message<Fact>>) -> Runner {
+        let handles = plan.distribute()
+            .into_iter()
+            .map(|work| {
+                let collector = collector.clone();
+                let eng = eng.clone();
+                thread::spawn(move || Self::run(work, eng, &collector))
+            })
+            .collect();
+        Runner { handles }
+    }
+
+    /// After the runner has been started, it just be joined so that all of the work can
+    /// be finished.
+    pub fn join(self) {
+        self.handles
+            .into_iter()
+            .for_each(|h| h.join().expect("Sending thread to finish"));
+    }
+
+    fn run(work: usize, eng: Engine, collector: &Sender<Message<Fact>>) {
+        eng.run(work, |fact| {
+            collector
+                .send(Message::Body(fact))
+                .expect("to send the fact correctly");
+        });
+        collector
+            .send(Message::EOF)
+            .expect("to send None correctly");
+    }
+}

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -214,10 +214,7 @@ impl Summary {
             ChartSize::Large => (20, 1),
         };
         use stats::scale_array;
-        format!(
-            "{}",
-            Chart::new().height(height).make(&scale_array(&vec, scale))
-        )
+        Chart::new().height(height).make(&scale_array(&vec, scale))
     }
 }
 


### PR DESCRIPTION
To make the code more testable and to isolate some of the features,
I've extracted the collector and runner into their own modules. I've
also moved the message into it's own and created the idea of a "plan"

This has had the effect of minimizing the main code but also allowing
for future generics for each of the types. One plan for the future is
replace the engine with a trait so that there can be multiple
implementations of the engine. This will work even better with the
runner if we make the engine generic over the "facts" it produces.